### PR TITLE
docs: Chrome Extension, adapter, and deployment guides

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,0 +1,203 @@
+# Distribution Adapters
+
+ClawMark's distribution system routes item events (created, resolved, assigned, etc.) to external channels via configurable adapters. Configure adapters in `config.json` under the `distribution` key.
+
+## Configuration Structure
+
+```json
+{
+  "distribution": {
+    "rules": [...],
+    "channels": {...}
+  }
+}
+```
+
+### Rules
+
+Rules determine which events go to which channels. Each rule has a `match` condition and a list of target `channels`.
+
+```json
+{
+  "match": {
+    "event": "item.created",
+    "type": "issue",
+    "priority": ["high", "critical"]
+  },
+  "channels": ["telegram-alerts", "lark-dev"]
+}
+```
+
+**Match fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event` | string | Event type: `item.created`, `item.resolved`, `item.assigned`, `item.closed`, `message.added` |
+| `type` | string | Item type: `issue`, `discuss`, `comment` |
+| `priority` | string[] | Priority levels: `critical`, `high`, `medium`, `low` |
+| `tags` | string[] | Match items with any of these tags |
+
+All match fields are optional. Omitted fields match everything.
+
+### Channels
+
+Named channel configurations that reference an adapter type and its settings.
+
+## Available Adapters
+
+### Webhook
+
+Generic HTTP webhook with optional HMAC signature verification.
+
+```json
+{
+  "webhook-default": {
+    "adapter": "webhook",
+    "url": "https://your-service.com/webhook",
+    "secret": "optional-hmac-secret",
+    "method": "POST"
+  }
+}
+```
+
+**Payload format:** JSON with `event`, `item`, `timestamp` fields. When `secret` is set, requests include an `X-ClawMark-Signature` header (HMAC-SHA256).
+
+### Telegram
+
+Sends notifications to a Telegram chat via Bot API.
+
+```json
+{
+  "telegram-alerts": {
+    "adapter": "telegram",
+    "bot_token": "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11",
+    "chat_id": "-100123456789",
+    "parse_mode": "HTML",
+    "proxy": ""
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `bot_token` | Yes | Telegram Bot API token (from @BotFather) |
+| `chat_id` | Yes | Target chat/group/channel ID |
+| `parse_mode` | No | `"HTML"` (default) or `"MarkdownV2"` |
+| `proxy` | No | HTTP/SOCKS proxy URL for restricted networks |
+
+**Setup:**
+1. Create a bot via [@BotFather](https://t.me/BotFather)
+2. Get the bot token
+3. Add the bot to your target group/channel
+4. Get the `chat_id` (use `getUpdates` API or [@userinfobot](https://t.me/userinfobot))
+
+### Lark / Feishu
+
+Sends interactive card messages to a Lark webhook.
+
+```json
+{
+  "lark-dev": {
+    "adapter": "lark",
+    "webhook_url": "https://open.larksuite.com/open-apis/bot/v2/hook/YOUR_HOOK_ID"
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `webhook_url` | Yes | Lark/Feishu Incoming Webhook URL |
+
+**Setup:**
+1. In your Lark group, add a Custom Bot (group settings → Bots → Add Bot)
+2. Copy the webhook URL
+3. Messages are sent as interactive cards with priority color coding
+
+### GitHub Issue
+
+Creates and syncs GitHub Issues from ClawMark items.
+
+```json
+{
+  "github-bugs": {
+    "adapter": "github-issue",
+    "token": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "repo": "your-org/your-repo",
+    "labels": ["clawmark", "bug"],
+    "assignees": ["username"]
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `token` | Yes | GitHub Personal Access Token with `repo` scope |
+| `repo` | Yes | Target repository in `owner/repo` format |
+| `labels` | No | Labels to add to created issues |
+| `assignees` | No | GitHub usernames to auto-assign |
+
+**Lifecycle sync:**
+- `item.created` → Creates a GitHub Issue
+- `item.resolved` → Closes the GitHub Issue
+- `item.closed` → Closes the GitHub Issue
+- `item.reopened` → Reopens the GitHub Issue
+
+## Example: Full Configuration
+
+```json
+{
+  "distribution": {
+    "rules": [
+      {
+        "match": { "event": "item.created", "type": "issue", "priority": ["high", "critical"] },
+        "channels": ["telegram-alerts", "lark-dev", "github-bugs"]
+      },
+      {
+        "match": { "event": "item.created", "type": "discuss" },
+        "channels": ["lark-dev"]
+      },
+      {
+        "match": { "event": "item.resolved" },
+        "channels": ["telegram-alerts", "github-bugs"]
+      }
+    ],
+    "channels": {
+      "telegram-alerts": {
+        "adapter": "telegram",
+        "bot_token": "YOUR_BOT_TOKEN",
+        "chat_id": "YOUR_CHAT_ID"
+      },
+      "lark-dev": {
+        "adapter": "lark",
+        "webhook_url": "YOUR_LARK_WEBHOOK"
+      },
+      "github-bugs": {
+        "adapter": "github-issue",
+        "token": "YOUR_GITHUB_TOKEN",
+        "repo": "your-org/your-repo",
+        "labels": ["clawmark"]
+      }
+    }
+  }
+}
+```
+
+## Writing Custom Adapters
+
+Create a new file in `server/adapters/` that exports a class with:
+
+```javascript
+export class MyAdapter {
+  constructor(channelConfig) {
+    // channelConfig = the channel object from config.json
+  }
+
+  async send(event, item, channelConfig) {
+    // event: { type: 'item.created', ... }
+    // item: the full item object
+    // Return true on success
+  }
+}
+```
+
+Register it in `server/adapters/index.js` by adding to the adapter registry.

--- a/docs/chrome-extension.md
+++ b/docs/chrome-extension.md
@@ -1,0 +1,93 @@
+# Chrome Extension Development Guide
+
+## Prerequisites
+
+- Chrome or Chromium-based browser (version 116+, Manifest V3 support)
+- ClawMark server running locally or on staging
+
+## Loading the Extension (Development)
+
+1. Open `chrome://extensions/` in your browser
+2. Enable **Developer mode** (toggle in top-right)
+3. Click **Load unpacked**
+4. Select the `extension/` directory from this repository
+
+The extension will appear in your toolbar. Click the icon to open the popup.
+
+## Project Structure
+
+```
+extension/
+├── manifest.json              # Manifest V3 configuration
+├── background/
+│   └── service-worker.js      # Auth, API calls, context menu
+├── content/
+│   ├── inject.js              # Text selection, floating toolbar
+│   └── inject.css             # Toolbar + input overlay styles
+├── popup/
+│   ├── popup.html             # Settings UI
+│   └── popup.js               # Config management
+├── sidepanel/
+│   ├── panel.html             # Issue list + thread view
+│   └── panel.js               # Data loading, rendering
+└── icons/
+    ├── generate.html           # Icon generation helper
+    ├── icon-16.png
+    ├── icon-32.png
+    ├── icon-48.png
+    └── icon-128.png
+```
+
+## Configuration
+
+After loading, click the extension icon to open the popup and configure:
+
+- **Server URL**: Your ClawMark server URL (e.g., `http://localhost:3462` for local dev)
+- **Invite Code**: The auth code configured in your server's `config.json`
+
+## Key Components
+
+### Service Worker (`background/service-worker.js`)
+
+Handles:
+- Authentication state management
+- API calls to ClawMark server
+- Context menu integration (right-click to report)
+- Message routing between content script and popup/side panel
+
+### Content Script (`content/inject.js`)
+
+Injected into all pages. Provides:
+- Text selection detection with floating toolbar
+- Input overlay for quick feedback
+- Communication with service worker via `chrome.runtime.sendMessage`
+
+### Side Panel (`sidepanel/panel.js`)
+
+Chrome's built-in side panel showing:
+- List of items for the current page
+- Thread view with messages
+- Reply functionality
+
+## Debugging
+
+- **Service worker logs**: Go to `chrome://extensions/` → click "service worker" link under your extension
+- **Content script logs**: Open DevTools on any page → Console tab (filter by "ClawMark")
+- **Popup/Side panel**: Right-click the popup → Inspect
+
+## Building for Production
+
+Currently no build step is required — the extension uses vanilla JS modules. To prepare for Chrome Web Store:
+
+1. Generate icons: Open `extension/icons/generate.html` in a browser, save the generated PNGs
+2. Create a ZIP of the `extension/` directory
+3. Upload to [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole)
+
+## Coexistence with Widget
+
+The Chrome Extension and the embedded widget can run on the same page. They share the same server API but operate independently:
+
+- The widget is embedded by the page developer (via `<script>` tag)
+- The extension is installed by the end user
+- Both use the same V2 API endpoints
+- Items created by either are visible to both

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,141 @@
+# Self-Hosted Deployment Guide
+
+## Quick Start
+
+### Option 1: Node.js
+
+```bash
+git clone https://github.com/coco-xyz/clawmark.git
+cd clawmark
+npm install
+cp server/config.example.json config.json
+# Edit config.json with your settings
+npm start
+```
+
+Server runs on `http://localhost:3458` by default.
+
+### Option 2: PM2 (Production)
+
+```bash
+npm install -g pm2
+
+# Start with PM2
+pm2 start server/index.js --name clawmark -- --config ./config.json
+
+# Save PM2 process list
+pm2 save
+
+# Auto-start on boot
+pm2 startup
+```
+
+## Environment Variables
+
+Override config.json settings via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAWMARK_PORT` | `3458` | Server port |
+| `CLAWMARK_DATA_DIR` | `./data` | SQLite database + uploads directory |
+| `CLAWMARK_CONFIG` | `../config.json` | Path to config file |
+| `CLAWMARK_ENV` | `production` | Environment name (`production`, `staging`) |
+| `CLAWMARK_WEBHOOK_URL` | — | Webhook endpoint (overrides config) |
+| `CLAWMARK_WEBHOOK_SECRET` | — | Webhook HMAC secret |
+| `CLAWMARK_INVITE_CODES_JSON` | — | JSON invite codes (overrides config) |
+
+## Reverse Proxy (Caddy)
+
+```
+clawmark.example.com {
+    reverse_proxy localhost:3458
+}
+```
+
+## Reverse Proxy (Nginx)
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name clawmark.example.com;
+
+    location / {
+        proxy_pass http://localhost:3458;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+## Data & Backups
+
+All data is stored in the `dataDir` directory:
+
+```
+data/
+├── clawmark.db          # SQLite database (items, messages, users)
+└── uploads/             # Uploaded images
+```
+
+**Backup:** Copy the entire `data/` directory. SQLite is a single file — stop the server or use `.backup` for consistent snapshots.
+
+## Health Check
+
+```bash
+curl http://localhost:3458/health
+# Returns: {"status":"ok","version":"2.0.0"}
+```
+
+## Authentication
+
+ClawMark uses an invite code system. Configure codes in `config.json`:
+
+```json
+{
+  "auth": {
+    "type": "invite-code",
+    "codes": {
+      "team-code-1": "Alice",
+      "team-code-2": "Bob",
+      "guest-code": "Guest"
+    }
+  }
+}
+```
+
+Each code maps to a display name. Users enter the code in the widget or extension popup to authenticate.
+
+## Multi-Tenant Mode
+
+Serve multiple apps from one server using path-based routing:
+
+```
+/api/clawmark/:app/items    → Items for specific app
+/items                       → Items using default app ID
+```
+
+The `app` parameter isolates data per application. Configure the widget with matching `app` values:
+
+```javascript
+const cm = new ClawMark({ api: 'https://clawmark.example.com', app: 'my-app' });
+```
+
+## Monitoring
+
+### PM2
+
+```bash
+pm2 monit           # Real-time monitoring
+pm2 logs clawmark   # View logs
+pm2 status          # Process status
+```
+
+### Log Output
+
+The server logs to stdout. Use PM2 log management or redirect to a file:
+
+```bash
+pm2 start server/index.js --name clawmark --log /var/log/clawmark.log
+```


### PR DESCRIPTION
## Summary
- Chrome Extension development setup, debugging, and production build guide
- Distribution adapter reference (Telegram, Lark, GitHub Issue, Webhook) with config examples
- Self-hosted deployment guide (Node.js, PM2, Caddy/Nginx reverse proxy, data backup)

Ref #15