### PR TITLE
feat: persist GitHub Issue adapter mappings in SQLite (#10)

### DIFF
--- a/server/adapters/index.js
+++ b/server/adapters/index.js
@@ -15,6 +15,16 @@ class AdapterRegistry {
         this.channels = new Map();
         /** @type {Array} routing rules from config */
         this.rules = [];
+        /** @type {object|null} DB instance for adapters that need persistence */
+        this.db = null;
+    }
+
+    /**
+     * Set the database instance. Call before loadConfig so adapters get the DB.
+     * @param {object} db  The ClawMark DB API from initDb().
+     */
+    setDb(db) {
+        this.db = db;
     }
 
     /**
@@ -43,7 +53,7 @@ class AdapterRegistry {
                 continue;
             }
             try {
-                const instance = new AdapterClass(channelConfig);
+                const instance = new AdapterClass({ ...channelConfig, channelName: name, db: this.db || null });
                 const validation = instance.validate ? instance.validate() : { ok: true };
                 if (!validation.ok) {
                     console.warn(`[adapters] Channel "${name}" validation failed: ${validation.error}`);

--- a/server/index.js
+++ b/server/index.js
@@ -74,6 +74,7 @@ const { TelegramAdapter } = require('./adapters/telegram');
 const { GitHubIssueAdapter } = require('./adapters/github-issue');
 
 const registry = new AdapterRegistry();
+registry.setDb(itemsDb);
 registry.registerType('webhook', WebhookAdapter);
 registry.registerType('lark', LarkAdapter);
 registry.registerType('telegram', TelegramAdapter);


### PR DESCRIPTION
## Summary
- New `adapter_mappings` SQLite table with composite PK
- GitHubIssueAdapter uses DB when available, falls back to in-memory Map
- 3 new tests (in-memory, DB delegation, restart survival)

Fixes #10

Code by Lucy (rebased by Boot due to phantom PR issue on original branch).