### PR TITLE
feat: Widget V2 — source attribution, tags, screenshots

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -391,7 +391,8 @@ function handleGetItem(req, res) {
 
 // -- POST /items
 function handleCreateItem(req, res) {
-    const { doc, type, title, quote, quote_position, priority, message, userName, version } = req.body;
+    const { doc, type, title, quote, quote_position, priority, message, userName, version,
+            source_url, source_title, tags, screenshots } = req.body;
     const app_id = resolveAppId(req);
 
     if (!doc || !userName) return res.status(400).json({ error: 'Missing doc or userName' });
@@ -399,7 +400,8 @@ function handleCreateItem(req, res) {
 
     const item = itemsDb.createItem({
         app_id, doc, type: type || 'discuss', title, quote, quote_position,
-        priority: priority || 'normal', created_by: userName, version, message
+        priority: priority || 'normal', created_by: userName, version, message,
+        source_url, source_title, tags, screenshots
     });
 
     sendWebhook('item.created', { app_id, item });

--- a/widget/core/api-client.js
+++ b/widget/core/api-client.js
@@ -81,16 +81,21 @@ export class ApiClient {
   /**
    * Create a new item (discussion or issue).
    * @param {object} payload
-   * @param {string} payload.type    - 'discuss' | 'issue'
+   * @param {string} payload.type         - 'discuss' | 'issue'
    * @param {string} payload.doc
    * @param {string} payload.message
    * @param {string} [payload.quote]
+   * @param {string} [payload.quote_position] - JSON XPath position
    * @param {string} [payload.title]
    * @param {string} [payload.priority]
    * @param {string} [payload.userName]
+   * @param {string} [payload.source_url]    - Page URL where item was created
+   * @param {string} [payload.source_title]  - Page title
+   * @param {string[]} [payload.tags]        - Tag labels
+   * @param {string[]} [payload.screenshots] - Screenshot URLs
    */
   createItem(payload) {
-    return this._post('/items', {
+    const body = {
       doc: payload.doc || this.defaultDoc,
       type: payload.type,
       title: payload.title,
@@ -98,7 +103,13 @@ export class ApiClient {
       message: payload.message,
       quote: payload.quote,
       userName: payload.userName || 'anonymous',
-    });
+    };
+    if (payload.quote_position) body.quote_position = payload.quote_position;
+    if (payload.source_url)     body.source_url = payload.source_url;
+    if (payload.source_title)   body.source_title = payload.source_title;
+    if (payload.tags?.length)   body.tags = payload.tags;
+    if (payload.screenshots?.length) body.screenshots = payload.screenshots;
+    return this._post('/items', body);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Server: `handleCreateItem` now accepts V2 fields (`source_url`, `source_title`, `tags`, `screenshots`)
- API Client: `createItem` sends V2 fields when provided
- Widget Core: auto-detects source page URL and title via `detectSource()` on mount
- Fab Plugin: tag picker UI (bug/ui/feature/content/perf), tags in issue list + detail, source attribution in detail view
- Comment Plugin: sends `source_url`/`source_title` when creating discussions

Closes #14

## Test plan
- [x] All 35 existing tests pass
- [ ] Manual: embed widget on test page, create issue with tags → verify tags stored in DB
- [ ] Manual: verify source_url and source_title auto-populated from page context
- [ ] Manual: verify Chrome Extension and widget can coexist on same page

🤖 Generated with [Claude Code](https://claude.com/claude-code)