### PR TITLE
fix: adapter dispatch payload + createItem return

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -205,7 +205,9 @@ function initDb(dataDir) {
             });
         }
 
-        return { id: itemId, app_id, doc, type, status: 'open', created_at: now,
+        return { id: itemId, app_id, doc, type, status: 'open', priority,
+                 title: title || null, quote: quote || null,
+                 created_by, created_at: now, message: message || null,
                  source_url: source_url || null, source_title: source_title || null,
                  tags: tags || [], screenshots: screenshots || [] };
     }

--- a/server/index.js
+++ b/server/index.js
@@ -431,7 +431,7 @@ function handleCreateItem(req, res) {
         source_url, source_title, tags, screenshots
     });
 
-    sendWebhook('item.created', { app_id, item });
+    sendWebhook('item.created', item);
 
     res.json({ success: true, item });
 }
@@ -607,7 +607,7 @@ app.post('/api/v2/items', apiWriteLimiter, v2Auth, (req, res) => {
         screenshots: screenshots || [],
     });
 
-    sendWebhook('item.created', { app_id: resolvedAppId, item });
+    sendWebhook('item.created', item);
     res.json({ success: true, item });
 });
 


### PR DESCRIPTION
## Summary
- Fixed `sendWebhook` wrapping item in `{ app_id, item }` — adapters expect flat item object
- Fixed `createItem()` return missing `title`, `quote`, `priority`, `created_by`, `message` fields
- Both V1 and V2 API paths corrected

## Verified
GitHub Issue adapter now creates issues with complete content:
- Title: `[ClawMark] <title>`
- Body: type, priority, reporter, source URL/page, selected text, description, tags
- Labels: auto-generated from type, priority, tags

## Test plan
- [x] Created test item via API → verified GitHub Issue #31 had all fields
- [x] Cleaned up test issues
- [ ] Boot: review code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)