### PR TITLE
fix: auto-refresh side panel after item creation

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -151,8 +151,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 async function handleMessage(message, sender) {
     switch (message.type) {
-        case 'CREATE_ITEM':
-            return createItem(message.data);
+        case 'CREATE_ITEM': {
+            const result = await createItem(message.data);
+            // Notify side panel to refresh after item creation
+            chrome.runtime.sendMessage({ type: 'ITEM_CREATED' }).catch(() => {});
+            return result;
+        }
 
         case 'GET_ITEMS_BY_URL':
             return getItemsByUrl(message.url);

--- a/extension/sidepanel/panel.js
+++ b/extension/sidepanel/panel.js
@@ -297,6 +297,16 @@ function escapeHtml(str) {
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+// ------------------------------------------------------------------ cross-script events
+
+// Auto-refresh when content script creates a new item
+chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === 'ITEM_CREATED') {
+        invalidateCache(`items:${currentUrl}`);
+        loadItems(true);
+    }
+});
+
 // ------------------------------------------------------------------ start
 
 init();


### PR DESCRIPTION
## Summary
- Fixes #37 — side panel now auto-refreshes after creating an item from the content script
- Background service worker broadcasts `ITEM_CREATED` event after successful creation
- Side panel listens for this event and reloads item list (with cache invalidation)

## Changes
- `extension/background/service-worker.js`: broadcast `ITEM_CREATED` after `createItem` succeeds
- `extension/sidepanel/panel.js`: listen for `ITEM_CREATED` and auto-reload

## Test plan
- [ ] Open side panel, create a comment/issue via text selection
- [ ] Verify side panel updates automatically without manual refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)