### PR TITLE
chore: downgrade version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 格式，版本号采用 [语义化版本](https://semver.org/lang/zh-CN/)。
 
-## [2.0.0] — 2026-02-28
+## [0.2.0] — 2026-02-28
 
 ### 新增
 
@@ -37,5 +37,5 @@
 - JSON body 大小限制（512KB）
 - 不存在 item 的状态操作返回 404
 
-[2.0.0]: https://github.com/coco-xyz/clawmark/releases/tag/v2.0.0
+[0.2.0]: https://github.com/coco-xyz/clawmark/releases/tag/v0.2.0
 [0.1.0]: https://github.com/coco-xyz/clawmark/commits/0c02d6b

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ClawMark",
-  "version": "2.0.0",
+  "version": "0.2.0",
   "description": "标注、评论、追踪 — 在任意网页上收集反馈",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
## Summary
- manifest.json 版本号 2.0.0 → 0.2.0
- CHANGELOG.md 对应更新

Kevin 要求：项目还在 pre-1.0，版本号改成 0.x.y

## Test plan
- [ ] Verify manifest.json shows 0.2.0
- [ ] Verify CHANGELOG.md references 0.2.0