### PR TITLE
Fix critical routing and auth bugs (v0.3.0)

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -440,7 +440,7 @@ function initDb(dataDir) {
                 ? (typeof updates.target_config === 'string' ? updates.target_config : JSON.stringify(updates.target_config))
                 : existing.target_config,
             priority: updates.priority ?? existing.priority,
-            enabled: updates.enabled !== undefined ? updates.enabled : existing.enabled,
+            enabled: updates.enabled !== undefined ? (updates.enabled ? 1 : 0) : existing.enabled,
             updated_at: now,
         };
         ruleStmts.updateRule.run(merged);


### PR DESCRIPTION
## Summary

Fixes 5 bugs discovered during v0.3.0 testing by Lucy and Boot:

### Critical — Routing Core
- **url_pattern `*` wildcard didn't cross path segments** — `*github.com*` failed to match `github.com/org/repo/...`. Root cause: `*` was converted to `[^/]*` (Boot's analysis). Now uses `.*`.
- **tag_match rules never matched** — rule type was accepted by CRUD but `resolveTarget()` had no matching logic. Now implemented.

### Security
- **GET /api/v2/items and /routing/rules had no auth** — `v2Auth` middleware allowed all GETs without authentication, exposing all annotation content and routing rules. Fixed by removing the GET pass-through.

### Other Fixes
- **`enabled: false` caused 500** — JavaScript boolean `false` wasn't converted to SQLite INTEGER. Now coerced to `0`/`1`.
- **target_config double serialization** — Rules API returned `target_config` as JSON string instead of parsed object. Now parsed before response.

## Test Plan
- [x] All 117 tests pass (8 new tests covering the fixes)
- [ ] Lucy runs regression test on deployed API
- [ ] Verify `*github.com*` pattern now matches in routing resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)