### PR TITLE
chore: set Google OAuth Client ID in extension

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -15,8 +15,7 @@
 const DEFAULT_SERVER = 'https://clawmark.coco.xyz';
 
 // Google OAuth client ID — set by server admin via CLAWMARK_GOOGLE_CLIENT_ID
-// TODO: Replace with actual client ID from Jessie's OAuth setup
-const GOOGLE_CLIENT_ID = '';
+const GOOGLE_CLIENT_ID = '530440081185-32t15m4gqndq7qab6g57a25i6gfc1gmn.apps.googleusercontent.com';
 
 async function getConfig() {
     const result = await chrome.storage.sync.get({


### PR DESCRIPTION
## Summary
- Set the Google OAuth Web Client ID in `extension/background/service-worker.js`
- Client ID from GCP project `clawmark-coco` (created by Jessie)
- Enables Google login via `chrome.identity.launchWebAuthFlow()` without manual configuration

## Context
- GCP project: clawmark-coco (under bitlayer.ltd org)
- OAuth consent screen: External, Testing mode
- Test users: jessie@coco.xyz, kevin@coco.xyz, elonhe668@gmail.com
- Web client configured with JS origins: api.coco.xyz, jessie.coco.site
- Redirect URIs: api.coco.xyz/auth/google/callback, jessie.coco.site/clawmark/auth/google/callback

## Test plan
- [ ] Boot: end-to-end test extension login flow (#67)
- [ ] Verify OAuth consent screen appears with ClawMark branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)