### PR TITLE
feat: smart dispatch preview & status display (#115)

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -399,6 +399,14 @@ async function handleMessage(message, sender) {
         case 'UPLOAD_IMAGE':
             return uploadImage(message.dataUrl);
 
+        // Dispatch target preview (#115)
+        case 'RESOLVE_DISPATCH_TARGETS':
+            return apiRequest('POST', '/api/v2/routing/resolve', {
+                source_url: message.source_url,
+                type: message.item_type,
+                tags: message.tags,
+            });
+
         // Routing rules CRUD
         case 'GET_ROUTING_RULES':
             return apiRequest('GET', '/api/v2/routing/rules');

--- a/extension/content/inject.css
+++ b/extension/content/inject.css
@@ -180,6 +180,60 @@
     cursor: not-allowed;
 }
 
+/* ---- Dispatch Preview (#115) ---- */
+#clawmark-input-overlay .cm-dispatch-preview {
+    margin: 4px 12px 0;
+    padding: 6px 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid #2a2a3e;
+    border-radius: 6px;
+}
+
+#clawmark-input-overlay .cm-dispatch-label {
+    font-size: 10px;
+    font-weight: 600;
+    color: #888;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 4px;
+}
+
+#clawmark-input-overlay .cm-dispatch-target {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 0;
+    cursor: pointer;
+    font-size: 12px;
+    color: #ccc;
+}
+
+#clawmark-input-overlay .cm-dispatch-target input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    accent-color: #5865f2;
+    cursor: pointer;
+}
+
+#clawmark-input-overlay .cm-target-icon {
+    font-size: 13px;
+    flex-shrink: 0;
+}
+
+#clawmark-input-overlay .cm-target-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+#clawmark-input-overlay .cm-target-method {
+    font-size: 10px;
+    color: #666;
+    flex-shrink: 0;
+}
+
 /* ---- Toast notification ---- */
 #clawmark-toast {
     position: fixed;

--- a/extension/sidepanel/panel.html
+++ b/extension/sidepanel/panel.html
@@ -272,6 +272,61 @@
             font-size: 12px;
             margin: 8px 0;
         }
+
+        /* ---- Dispatch Badges (#115) ---- */
+        .dispatch-badges {
+            display: flex;
+            gap: 4px;
+            margin: 4px 0;
+        }
+
+        .dispatch-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 22px;
+            height: 22px;
+            border: 1.5px solid;
+            border-radius: 4px;
+            font-size: 12px;
+            cursor: default;
+        }
+
+        .dispatch-details {
+            margin-top: 8px;
+            padding: 8px;
+            background: rgba(255,255,255,0.03);
+            border: 1px solid #2a2a3e;
+            border-radius: 6px;
+        }
+
+        .dispatch-details-label {
+            font-size: 10px;
+            font-weight: 600;
+            color: #888;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 4px;
+        }
+
+        .dispatch-detail-row {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 3px 0;
+            font-size: 12px;
+        }
+
+        .dispatch-detail-type { color: #ccc; }
+        .dispatch-detail-status { font-size: 11px; }
+
+        .dispatch-link {
+            color: #5865f2;
+            text-decoration: none;
+            font-size: 13px;
+        }
+
+        .dispatch-link:hover { text-decoration: underline; }
     </style>
 </head>
 <body>

--- a/extension/sidepanel/panel.js
+++ b/extension/sidepanel/panel.js
@@ -197,6 +197,7 @@ function renderItems() {
                 </div>
                 ${item.title ? `<div class="item-title">${escapeHtml(item.title)}</div>` : ''}
                 ${item.quote ? `<div class="item-quote">${escapeHtml(item.quote)}</div>` : ''}
+                ${renderDispatchBadges(item.dispatches)}
                 <div class="item-meta">
                     <span>${item.created_by}</span>
                     <span>${time}</span>
@@ -224,6 +225,7 @@ function renderThread(item) {
             ${item.title ? `<div class="item-title">${escapeHtml(item.title)}</div>` : ''}
             ${item.quote ? `<div class="item-quote">${escapeHtml(item.quote)}</div>` : ''}
             ${tags.length > 0 ? `<div class="item-tags">${tags.map(t => `<span class="tag">${escapeHtml(t)}</span>`).join('')}</div>` : ''}
+            ${renderDispatchDetails(item.dispatches)}
         </div>
     `;
 
@@ -295,6 +297,46 @@ function formatTime(isoString) {
 function escapeHtml(str) {
     if (!str) return '';
     return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// ------------------------------------------------------------------ dispatch display (#115)
+
+const TARGET_ICONS = {
+    'github-issue': '\u{1F4CB}', lark: '\u{1F426}', telegram: '\u{2709}',
+    webhook: '\u{1F517}', slack: '\u{1F4AC}', email: '\u{1F4E7}',
+    linear: '\u25B6', jira: '\u{1F3AF}', 'hxa-connect': '\u{1F310}',
+};
+
+const STATUS_COLORS = { sent: '#22c55e', pending: '#eab308', failed: '#ef4444' };
+
+function renderDispatchBadges(dispatches) {
+    if (!dispatches || dispatches.length === 0) return '';
+    return `<div class="dispatch-badges">${dispatches.map(d => {
+        const icon = TARGET_ICONS[d.target_type] || '\u27A1';
+        const color = STATUS_COLORS[d.status] || '#888';
+        const title = `${d.target_type} (${d.method?.replace('_', ' ') || ''}) \u2014 ${d.status}`;
+        return `<span class="dispatch-badge" style="border-color:${color}" title="${escapeHtml(title)}">${icon}</span>`;
+    }).join('')}</div>`;
+}
+
+function renderDispatchDetails(dispatches) {
+    if (!dispatches || dispatches.length === 0) return '';
+    return `<div class="dispatch-details">
+        <div class="dispatch-details-label">Dispatched to:</div>
+        ${dispatches.map(d => {
+            const icon = TARGET_ICONS[d.target_type] || '\u27A1';
+            const color = STATUS_COLORS[d.status] || '#888';
+            const linkHtml = d.external_url
+                ? `<a href="${escapeHtml(d.external_url)}" target="_blank" class="dispatch-link">\u2197</a>`
+                : '';
+            return `<div class="dispatch-detail-row">
+                <span>${icon}</span>
+                <span class="dispatch-detail-type">${escapeHtml(d.target_type)}</span>
+                <span class="dispatch-detail-status" style="color:${color}">${d.status}</span>
+                ${linkHtml}
+            </div>`;
+        }).join('')}
+    </div>`;
 }
 
 // ------------------------------------------------------------------ cross-script events


### PR DESCRIPTION
## Summary
- **Before submit**: input overlay now shows all dispatch targets with checkboxes — user sees WHERE their item will go and can deselect unwanted targets
- **After submit**: item cards in side panel show dispatch badges (icon + status color), thread view shows full dispatch details with external links
- **Server**: `/api/v2/routing/resolve` returns all matching targets (was single), items list includes dispatch log, item creation accepts `selected_targets` to filter dispatch

## Changes
| File | What |
|------|------|
| `server/index.js` | Resolve returns all targets; items list includes dispatches; selected_targets filter |
| `extension/content/inject.js` | Dispatch preview fetch + checkboxes + submit with selection |
| `extension/content/inject.css` | Styles for dispatch target list |
| `extension/background/service-worker.js` | `RESOLVE_DISPATCH_TARGETS` message handler |
| `extension/sidepanel/panel.js` | `renderDispatchBadges()` + `renderDispatchDetails()` |
| `extension/sidepanel/panel.html` | CSS for badges and detail rows |

## Test plan
- [x] 491/491 existing tests pass
- [ ] Manual: open extension on a page with routing rules → verify dispatch preview shows in input overlay
- [ ] Manual: deselect a target → verify only selected targets receive dispatch
- [ ] Manual: check side panel item cards show dispatch badges after submission
- [ ] Manual: open thread view → verify dispatch details section with status and links

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)