### PR TITLE
fix: escape HTML in dispatch target labels (#115)

### DIFF
--- a/extension/content/inject.js
+++ b/extension/content/inject.js
@@ -379,8 +379,8 @@
                 return `<label class="cm-dispatch-target">
                     <input type="checkbox" checked data-idx="${i}" />
                     <span class="cm-target-icon">${getTargetIcon(t.target_type)}</span>
-                    <span class="cm-target-label">${label}</span>
-                    <span class="cm-target-method">${t.method.replace('_', ' ')}</span>
+                    <span class="cm-target-label">${escHtml(label)}</span>
+                    <span class="cm-target-method">${escHtml(t.method.replace('_', ' '))}</span>
                 </label>`;
             }).join('');
             previewEl.style.display = 'block';
@@ -415,6 +415,11 @@
             'hxa-connect': '\u{1F310}',
         };
         return icons[type] || '\u{27A1}';
+    }
+
+    function escHtml(s) {
+        if (!s) return '';
+        return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
     }
 
     function hideInputOverlay() {


### PR DESCRIPTION
## Summary
- `formatTargetLabel()` output was injected via innerHTML without escaping — repo names or config values containing `<` could break the DOM
- Added `escHtml()` helper and applied to label + method fields in dispatch preview

Followup to PR #129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)