### PR TITLE
fix: GitHub adapter token + OAuth config (#141)

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -142,6 +142,34 @@ Creates and syncs GitHub Issues from ClawMark items.
 - `item.closed` → Closes the GitHub Issue
 - `item.reopened` → Reopens the GitHub Issue
 
+#### Default GitHub Token (for dynamic dispatch)
+
+When ClawMark auto-detects a GitHub URL (e.g. a user annotates a PR page), it dynamically resolves the target repo but needs a token with `repo` scope to create issues. The token is resolved in this order:
+
+1. **Per-channel token** — the `token` field in the channel config (static rules)
+2. **Inherited from static channel** — if any `github-issue` channel is configured, its token is reused
+3. **Default token** — from the `CLAWMARK_GITHUB_TOKEN` environment variable or `distribution.defaultGitHubToken` in config.json
+
+Set the default token to ensure dynamic dispatch works even when no static GitHub channel is configured:
+
+```bash
+# Environment variable (recommended for production)
+export CLAWMARK_GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
+```json
+// Or in config.json under distribution
+{
+  "distribution": {
+    "defaultGitHubToken": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "rules": [...],
+    "channels": {...}
+  }
+}
+```
+
+The token needs `repo` scope for private repositories, or `public_repo` for public-only access.
+
 ## Example: Full Configuration
 
 ```json

--- a/server/adapters/index.js
+++ b/server/adapters/index.js
@@ -17,6 +17,8 @@ class AdapterRegistry {
         this.rules = [];
         /** @type {object|null} DB instance for adapters that need persistence */
         this.db = null;
+        /** @type {string|null} Default GitHub token for dynamic dispatch fallback */
+        this.defaultGitHubToken = null;
     }
 
     /**
@@ -25,6 +27,19 @@ class AdapterRegistry {
      */
     setDb(db) {
         this.db = db;
+    }
+
+    /**
+     * Set the default GitHub token for dynamic dispatch.
+     * Used as a fallback when no static github-issue channel is configured
+     * or when dynamically resolved targets (e.g. github_auto routing) lack a token.
+     *
+     * @param {string} token  GitHub Personal Access Token with repo scope
+     */
+    setDefaultGitHubToken(token) {
+        if (token) {
+            this.defaultGitHubToken = token;
+        }
     }
 
     /**
@@ -136,6 +151,33 @@ class AdapterRegistry {
     }
 
     /**
+     * Resolve GitHub token for dynamic dispatch.
+     * Priority: target_config.token > static channel token > defaultGitHubToken.
+     *
+     * @param {object} config  Target config (may be mutated to add token)
+     * @returns {boolean} true if a token was resolved
+     */
+    _resolveGitHubToken(config) {
+        if (config.token) return true;
+
+        // Try inheriting from a static github-issue channel
+        for (const [, adapter] of this.channels) {
+            if (adapter.type === 'github-issue' && adapter.token) {
+                config.token = adapter.token;
+                return true;
+            }
+        }
+
+        // Fall back to the default GitHub token (from env or config)
+        if (this.defaultGitHubToken) {
+            config.token = this.defaultGitHubToken;
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Dispatch an event to a dynamically resolved target (not from static rules).
      * Creates an ad-hoc adapter instance using the registered adapter type.
      *
@@ -152,17 +194,9 @@ class AdapterRegistry {
             return;
         }
 
-        // Inherit token from default channel config if not provided.
-        // This is safe because dynamic targets are still GitHub repos the user
-        // explicitly configured — we just reuse the PAT from the static config
-        // rather than requiring each rule to carry its own token.
-        if (target_type === 'github-issue' && !target_config.token) {
-            for (const [, adapter] of this.channels) {
-                if (adapter.type === 'github-issue' && adapter.token) {
-                    target_config.token = adapter.token;
-                    break;
-                }
-            }
+        // Resolve GitHub token from available sources
+        if (target_type === 'github-issue') {
+            this._resolveGitHubToken(target_config);
         }
 
         const channelName = `dynamic-${target_type}-${Date.now()}`;
@@ -251,14 +285,9 @@ class AdapterRegistry {
         // Copy config to avoid mutating caller's object (M3)
         const config = { ...target_config };
 
-        // Inherit token from default channel for github-issue
-        if (target_type === 'github-issue' && !config.token) {
-            for (const [, adapter] of this.channels) {
-                if (adapter.type === 'github-issue' && adapter.token) {
-                    config.token = adapter.token;
-                    break;
-                }
-            }
+        // Resolve GitHub token from available sources
+        if (target_type === 'github-issue') {
+            this._resolveGitHubToken(config);
         }
 
         const channelName = `dynamic-${target_type}-${Date.now()}`;

--- a/server/config.example.json
+++ b/server/config.example.json
@@ -13,6 +13,7 @@
     "secret": ""
   },
   "distribution": {
+    "defaultGitHubToken": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "rules": [
       {
         "match": { "event": "item.created", "type": "issue", "priority": ["high", "critical"] },

--- a/server/index.js
+++ b/server/index.js
@@ -6,9 +6,11 @@
  * variables or config.json.
  *
  * Environment variables (all optional):
- *   CLAWMARK_PORT       Port to listen on              (default: 3458)
- *   CLAWMARK_DATA_DIR   Directory for DB + uploads     (default: ./data)
- *   CLAWMARK_CONFIG     Path to config.json            (default: ../config.json)
+ *   CLAWMARK_PORT           Port to listen on              (default: 3458)
+ *   CLAWMARK_DATA_DIR       Directory for DB + uploads     (default: ./data)
+ *   CLAWMARK_CONFIG         Path to config.json            (default: ../config.json)
+ *   CLAWMARK_GITHUB_TOKEN   Default GitHub PAT for dynamic dispatch (repo scope)
+ *   CLAWMARK_JWT_SECRET     Secret for signing auth JWTs
  */
 
 'use strict';
@@ -113,6 +115,18 @@ registry.registerType('email', EmailAdapter);
 registry.registerType('linear', LinearAdapter);
 registry.registerType('jira', JiraAdapter);
 registry.registerType('hxa-connect', HxaConnectAdapter);
+
+// Default GitHub token for dynamic dispatch (auto-routed GitHub URLs).
+// Priority: env var > config.distribution.defaultGitHubToken > static channel inheritance.
+const DEFAULT_GITHUB_TOKEN = process.env.CLAWMARK_GITHUB_TOKEN
+    || (config.distribution && config.distribution.defaultGitHubToken)
+    || null;
+if (DEFAULT_GITHUB_TOKEN) {
+    registry.setDefaultGitHubToken(DEFAULT_GITHUB_TOKEN);
+    console.log('[adapters] Default GitHub token configured for dynamic dispatch');
+} else {
+    console.warn('[adapters] No default GitHub token — dynamic dispatch to GitHub will fail unless a static github-issue channel provides one');
+}
 
 // Load distribution config
 if (config.distribution) {

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -1843,3 +1843,94 @@ describe('AdapterRegistry — new adapter types integration', () => {
         assert.equal(registry.channels.has('bad'), false);
     });
 });
+
+// ============================ defaultGitHubToken tests (#141)
+
+describe('AdapterRegistry — defaultGitHubToken (#141)', () => {
+
+    it('_resolveGitHubToken returns false when no token source exists', () => {
+        const registry = new AdapterRegistry();
+        registry.registerType('github-issue', GitHubIssueAdapter);
+        const config = { repo: 'owner/repo' };
+        assert.equal(registry._resolveGitHubToken(config), false);
+        assert.equal(config.token, undefined);
+    });
+
+    it('_resolveGitHubToken uses defaultGitHubToken when no channels exist', () => {
+        const registry = new AdapterRegistry();
+        registry.registerType('github-issue', GitHubIssueAdapter);
+        registry.setDefaultGitHubToken('ghp_default_test_token');
+        const config = { repo: 'owner/repo' };
+        assert.equal(registry._resolveGitHubToken(config), true);
+        assert.equal(config.token, 'ghp_default_test_token');
+    });
+
+    it('_resolveGitHubToken prefers static channel token over default', () => {
+        const registry = new AdapterRegistry();
+        registry.registerType('github-issue', GitHubIssueAdapter);
+        registry.setDefaultGitHubToken('ghp_default_token');
+        registry.loadConfig({
+            rules: [],
+            channels: {
+                'gh-static': {
+                    adapter: 'github-issue',
+                    token: 'ghp_static_channel_token',
+                    repo: 'org/static-repo',
+                },
+            },
+        });
+        const config = { repo: 'owner/other-repo' };
+        assert.equal(registry._resolveGitHubToken(config), true);
+        assert.equal(config.token, 'ghp_static_channel_token');
+    });
+
+    it('_resolveGitHubToken preserves explicit token in config', () => {
+        const registry = new AdapterRegistry();
+        registry.registerType('github-issue', GitHubIssueAdapter);
+        registry.setDefaultGitHubToken('ghp_default_token');
+        const config = { repo: 'owner/repo', token: 'ghp_explicit_token' };
+        assert.equal(registry._resolveGitHubToken(config), true);
+        assert.equal(config.token, 'ghp_explicit_token');
+    });
+
+    it('setDefaultGitHubToken ignores falsy values', () => {
+        const registry = new AdapterRegistry();
+        registry.setDefaultGitHubToken(null);
+        assert.equal(registry.defaultGitHubToken, null);
+        registry.setDefaultGitHubToken('');
+        assert.equal(registry.defaultGitHubToken, null);
+        registry.setDefaultGitHubToken(undefined);
+        assert.equal(registry.defaultGitHubToken, null);
+    });
+
+    it('setDefaultGitHubToken sets a valid token', () => {
+        const registry = new AdapterRegistry();
+        registry.setDefaultGitHubToken('ghp_abc123');
+        assert.equal(registry.defaultGitHubToken, 'ghp_abc123');
+    });
+
+    it('_dispatchSingleTarget uses default token for github-issue', async () => {
+        const registry = new AdapterRegistry();
+        // Track what token the adapter receives
+        let capturedToken = null;
+        class MockGH {
+            constructor(cfg) {
+                this.type = 'github-issue';
+                capturedToken = cfg.token;
+            }
+            validate() { return { ok: true }; }
+            async send() { return { external_id: '42', external_url: 'https://example.com' }; }
+        }
+        registry.registerType('github-issue', MockGH);
+        registry.setDefaultGitHubToken('ghp_from_default');
+
+        await registry._dispatchSingleTarget(
+            'item.created',
+            { id: 'test-1' },
+            'github-issue',
+            { repo: 'owner/repo' },
+            {}
+        );
+        assert.equal(capturedToken, 'ghp_from_default');
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #141 — GitHub adapter push failure due to missing token on dynamic dispatch.

**Root cause:** When ClawMark auto-detects a GitHub URL and dynamically resolves the target repo, it creates a `target_config` without a token. The existing fallback only inherited tokens from statically configured channels — if no `github-issue` channel was loaded (e.g. missing `distribution` config), all dispatches failed with `Validation failed: Missing token`.

**Changes:**
- Add `CLAWMARK_GITHUB_TOKEN` env var support as a server-wide fallback token for GitHub adapter
- Add `distribution.defaultGitHubToken` config option as an alternative to the env var
- Extract `_resolveGitHubToken()` helper with clear priority chain: explicit config token > static channel token > default token
- Document `CLAWMARK_GITHUB_TOKEN` and `CLAWMARK_JWT_SECRET` in server header comments
- Update `docs/adapters.md` with token resolution documentation
- Update `config.example.json` with `defaultGitHubToken` field

**Token resolution priority:**
1. Per-target explicit `token` in config
2. Inherited from any loaded `github-issue` static channel
3. `CLAWMARK_GITHUB_TOKEN` env var / `distribution.defaultGitHubToken` config

## Test plan

- [x] All 520 existing tests pass
- [x] 7 new tests covering: no token source, default token fallback, static channel priority, explicit token preserved, falsy value handling, valid token set, end-to-end `_dispatchSingleTarget` with default token
- [ ] Deploy: set `CLAWMARK_GITHUB_TOKEN` env var in PM2 config for production, restart `clawmark-new`
- [ ] Verify Kevin's 9 failed annotations can be retried via `/api/v2/distributions/:id/retry`