### PR TITLE
fix: toolbar positioning and text annotation input (#144, #143)

### DIFF
--- a/extension/content/inject.js
+++ b/extension/content/inject.js
@@ -200,11 +200,15 @@
 
     // ----------------------------------------------------------- toolbar
 
-    function showToolbar(x, y) {
+    function showToolbar(centerX, y) {
         if (!toolbar) return;
-        toolbar.style.left = `${x}px`;
-        toolbar.style.top = `${y}px`;
         toolbar.classList.add('visible');
+        const tw = toolbar.offsetWidth;
+        const th = toolbar.offsetHeight;
+        const x = Math.max(0, Math.min(centerX - tw / 2, window.innerWidth - tw));
+        const clampedY = Math.max(0, Math.min(y, window.innerHeight - th));
+        toolbar.style.left = `${x}px`;
+        toolbar.style.top = `${clampedY}px`;
     }
 
     function hideToolbar() {
@@ -537,7 +541,7 @@
                     range: range.cloneRange(),
                     position: { x: rect.left + window.scrollX, y: rect.bottom + window.scrollY },
                 };
-                showToolbar(rect.left + (rect.width / 2) - 120, rect.bottom + 8);
+                showToolbar(rect.left + (rect.width / 2), rect.bottom + 8);
             } else {
                 currentSelection = null;
                 hideToolbar();

--- a/extension/content/screenshot.css
+++ b/extension/content/screenshot.css
@@ -241,8 +241,8 @@
 
 /* Inline text input for text annotations */
 #clawmark-annotation-editor .cm-ann-text-input {
-    position: fixed;
-    z-index: 2147483647;
+    position: absolute;
+    z-index: 10;
     background: rgba(0, 0, 0, 0.6);
     border: 1px solid #5865f2;
     border-radius: 4px;

--- a/extension/content/screenshot.js
+++ b/extension/content/screenshot.js
@@ -467,6 +467,7 @@
             annotations.push({ type: 'pen', color, points: [pos] });
         } else if (tool === 'text') {
             isDrawing = false;
+            e.preventDefault();
             showTextInput(pos);
         } else if (tool === 'number') {
             isDrawing = false;
@@ -536,15 +537,17 @@
     function showTextInput(pos) {
         if (textInputEl) textInputEl.remove();
 
+        const wrap = editorOverlay.querySelector('.cm-ann-canvas-wrap');
         const rect = canvas.getBoundingClientRect();
+        const wrapRect = wrap.getBoundingClientRect();
         const scaleX = rect.width / canvas.width;
         const scaleY = rect.height / canvas.height;
 
         textInputEl = document.createElement('input');
         textInputEl.type = 'text';
         textInputEl.className = 'cm-ann-text-input';
-        textInputEl.style.left = (rect.left + pos.x * scaleX) + 'px';
-        textInputEl.style.top = (rect.top + pos.y * scaleY - 12) + 'px';
+        textInputEl.style.left = (rect.left - wrapRect.left + pos.x * scaleX) + 'px';
+        textInputEl.style.top = (rect.top - wrapRect.top + pos.y * scaleY - 12) + 'px';
         textInputEl.style.color = color;
         textInputEl.placeholder = 'Type text...';
 
@@ -574,8 +577,8 @@
         });
         textInputEl.addEventListener('blur', commitText);
 
-        editorOverlay.appendChild(textInputEl);
-        textInputEl.focus();
+        wrap.appendChild(textInputEl);
+        requestAnimationFrame(() => { if (textInputEl) textInputEl.focus(); });
     }
 
     // ----------------------------------------------------------- redraw


### PR DESCRIPTION
## Summary
- **#144** (toolbar covers buttons): Replace hardcoded 120px half-width with dynamic `offsetWidth` measurement. Toolbar is now centered on the selection midpoint and clamped within viewport bounds on both axes.
- **#143** (text annotation not working): Fix text input not appearing or receiving focus in screenshot annotation editor. Root causes: browser mousedown default behavior interfering with focus, and `position: fixed` text input inside an animated overlay causing stacking context issues.

## Changes
- `inject.js`: `showToolbar()` now measures actual toolbar width, centers dynamically, and clamps within viewport
- `screenshot.js`: `preventDefault()` on canvas mousedown for text tool; text input positioned as `absolute` inside canvas-wrap instead of `fixed` on overlay; `focus()` deferred via `requestAnimationFrame`
- `screenshot.css`: Text input changed from `position: fixed; z-index: 2147483647` to `position: absolute; z-index: 10`

## Test plan
- [ ] Select text on a page → toolbar should appear centered below selection
- [ ] Select text near edge of viewport → toolbar should not overflow
- [ ] In screenshot annotation editor, select text tool → click on canvas → text input should appear and receive focus
- [ ] Type text and press Enter → text should render on canvas
- [ ] Click Escape in text input → input should cancel without adding text

Closes #144, Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)