### PR TITLE
feat: delivery address fallback + visible dispatch targets (#147)

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -185,7 +185,7 @@ async function apiRequest(method, path, body = null) {
 // ------------------------------------------------------------------ API methods
 
 async function createItem({ type, title, content, source_url, source_title, quote,
-                            quote_position, priority, tags, screenshots }) {
+                            quote_position, priority, tags, screenshots, selected_targets }) {
     const config = await getConfig();
     return apiRequest('POST', '/api/v2/items', {
         type: type || 'comment',
@@ -199,6 +199,7 @@ async function createItem({ type, title, content, source_url, source_title, quot
         tags: tags || [],
         screenshots: screenshots || [],
         app_id: config.appId,
+        selected_targets,
     });
 }
 

--- a/extension/content/inject.css
+++ b/extension/content/inject.css
@@ -234,6 +234,13 @@
     flex-shrink: 0;
 }
 
+#clawmark-input-overlay .cm-dispatch-fallback {
+    opacity: 0.6;
+    border-top: 1px solid #333;
+    margin-top: 2px;
+    padding-top: 5px;
+}
+
 /* ---- Toast notification ---- */
 #clawmark-toast {
     position: fixed;

--- a/extension/content/inject.js
+++ b/extension/content/inject.js
@@ -369,12 +369,8 @@
             });
 
             resolvedTargets = result.targets || [];
-            if (resolvedTargets.length === 0) {
-                previewEl.style.display = 'none';
-                return;
-            }
 
-            targetsEl.innerHTML = resolvedTargets.map((t, i) => {
+            let html = resolvedTargets.map((t, i) => {
                 const label = formatTargetLabel(t);
                 return `<label class="cm-dispatch-target">
                     <input type="checkbox" checked data-idx="${i}" />
@@ -383,9 +379,26 @@
                     <span class="cm-target-method">${escHtml(t.method.replace('_', ' '))}</span>
                 </label>`;
             }).join('');
+
+            // Always show the ClawMark fallback destination
+            html += `<label class="cm-dispatch-target cm-dispatch-fallback">
+                <input type="checkbox" checked disabled />
+                <span class="cm-target-icon">\u{1F4BE}</span>
+                <span class="cm-target-label">ClawMark</span>
+                <span class="cm-target-method">saved</span>
+            </label>`;
+
+            targetsEl.innerHTML = html;
             previewEl.style.display = 'block';
         } catch {
-            previewEl.style.display = 'none';
+            // Even on error, show the fallback
+            targetsEl.innerHTML = `<label class="cm-dispatch-target cm-dispatch-fallback">
+                <input type="checkbox" checked disabled />
+                <span class="cm-target-icon">\u{1F4BE}</span>
+                <span class="cm-target-label">ClawMark</span>
+                <span class="cm-target-method">saved</span>
+            </label>`;
+            previewEl.style.display = 'block';
         }
     }
 
@@ -497,8 +510,16 @@
         try {
             const response = await chrome.runtime.sendMessage({ type: 'CREATE_ITEM', data });
             if (response.error) throw new Error(response.error);
-            const targetCount = resolvedTargets.length;
-            showToast(targetCount > 0 ? `Submitted \u2192 ${targetCount} target${targetCount > 1 ? 's' : ''}` : 'Submitted!', 'success');
+
+            // Build informative toast with dispatch destinations
+            const dispatched = response.dispatched || [];
+            const targetNames = dispatched.length > 0
+                ? dispatched.map(d => d.label || d.target_type).join(', ')
+                : resolvedTargets.map(t => formatTargetLabel(t)).join(', ');
+            const summary = targetNames
+                ? `Saved \u2192 ${targetNames}`
+                : 'Saved to ClawMark';
+            showToast(summary, 'success');
             resolvedTargets = [];
             hideInputOverlay();
         } catch (err) {


### PR DESCRIPTION
## Summary
- **Fallback endpoint**: Dispatch preview now always shows "ClawMark (saved)" as a guaranteed fallback destination, even when no routing rules match or the resolve call fails
- **Pre-submit visibility**: Users always see where their submission will go before clicking Submit
- **Post-submit visibility**: Toast now shows actual target names (e.g., "Saved → owner/repo, Webhook") instead of just a count
- **Bug fix**: `selected_targets` from the dispatch checkboxes was collected but never sent to the server — now forwarded to `/api/v2/items`

## Changes
- `service-worker.js`: `createItem()` accepts and forwards `selected_targets` to the API
- `inject.js`: `loadDispatchPreview()` always shows fallback row; `handleSubmit()` builds informative toast with target names from server response or client-side resolved targets
- `inject.css`: Styling for `.cm-dispatch-fallback` (dimmed, separator line)

## Test plan
- [ ] Open comment overlay on a page with no routing rules → should show "ClawMark (saved)" as destination
- [ ] Open comment overlay on a page with routing rules → should show configured targets + ClawMark fallback
- [ ] Uncheck some targets and submit → verify only selected targets are sent (server-side)
- [ ] Submit and check toast message shows target names, not just count
- [ ] Disconnect server / simulate error → dispatch preview should still show ClawMark fallback

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)