### PR TITLE
fix: prevent Google OAuth re-trigger on page refresh (v0.6.2)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "ClawMark",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "Annotate, comment, and track issues on any webpage — your feedback collection tool",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApkQ68vPnMba+IXLSgvs/91voPszurmDMdFQx6pEqi8bcSsGZr05NJ1VvFpVMu3X/lml6ZBLPfxdeJef803Hw3LH1g50FsvRS7OyooYkyzU7W3BXd4yBsaUUG7jdk4eVnaxTtINVXL0Z6YHAlA2YAV/e3tW7lY1MDYT+Fhpw2V4pOM5wNPD8NxPzSQxKiCZBN75aTHaHHz0LvXegSit3v8MXnmcWlBQNbCaK2aOAJbyVTv2jn+NR4VXKXNvK1cgLHJmGuXtdojBZwclyLSJ4jdDtM5uKQg509o8qljcrAGNU6fuO5ryLqS0EB3s/uN600LfuFqWGVJF1Wv/FpTgAyQwIDAQAB",
     "permissions": [

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -787,11 +787,21 @@ function handleTabParam() {
     if (!tab) return;
     const navItem = document.querySelector(`.nav-item[data-tab="${tab}"]`);
     if (navItem) navItem.click();
-    // Handle login=1 trigger
+    // Handle login=1 trigger — only if not already logged in
     if (params.get('login') === '1') {
-        setTimeout(() => {
+        // Clean URL to prevent re-triggering on refresh
+        const cleanUrl = new URL(window.location.href);
+        cleanUrl.searchParams.delete('login');
+        history.replaceState(null, '', cleanUrl.toString());
+
+        // Only auto-click login if user is not already authenticated
+        chrome.runtime.sendMessage({ type: 'GET_AUTH_STATE' }).then(state => {
+            if (!state.authToken || !state.authUser) {
+                document.getElementById('btn-google-login')?.click();
+            }
+        }).catch(() => {
             document.getElementById('btn-google-login')?.click();
-        }, 300);
+        });
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawmark",
-  "version": "0.5.0",
+  "version": "0.6.2",
   "description": "AI-native feedback & collaboration widget — annotate, comment, and track issues on any web page",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Fix: `?login=1` URL parameter was persisting across page refreshes, causing Google Sign In popup to open every time the Account tab loaded
- Uses `history.replaceState` to clean URL immediately + checks auth state before triggering OAuth
- Bumps version to 0.6.2

## Test plan
- [ ] Open welcome page → click Login with Google → complete OAuth
- [ ] Verify: refresh Account page — should NOT open Google Sign In popup
- [ ] Verify: URL no longer contains `login=1` after login completes
- [ ] Load extension from zip, confirm v0.6.2 shows in About tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)