### PR TITLE
feat: add brand/project info to About panel (#165)

### DIFF
--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -267,9 +267,18 @@
                 <h3>ClawMark</h3>
                 <p>Annotate, comment, and track issues on any webpage.</p>
                 <p>Version: <strong id="about-version">—</strong></p>
+                <p>Latest Release: <strong id="about-latest-version">checking...</strong></p>
             </div>
             <div class="card">
-                <h3>Links</h3>
+                <h3>Project</h3>
+                <ul class="link-list">
+                    <li><a href="https://labs.coco.xyz/clawmark/" target="_blank">Official Website</a></li>
+                    <li><a href="https://github.com/coco-xyz/clawmark" target="_blank">GitHub Repository</a></li>
+                    <li><a href="https://github.com/coco-xyz/clawmark/releases" target="_blank">Releases</a></li>
+                </ul>
+            </div>
+            <div class="card">
+                <h3>Help</h3>
                 <ul class="link-list">
                     <li><a href="https://github.com/coco-xyz/clawmark/issues" target="_blank">Report an Issue</a></li>
                     <li><a href="https://labs.coco.xyz/clawmark/privacy/" target="_blank">Privacy Policy</a></li>

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -718,6 +718,26 @@ document.getElementById('btn-toggle-all-sites')?.addEventListener('click', async
 function loadAbout() {
     const manifest = chrome.runtime.getManifest();
     document.getElementById('about-version').textContent = manifest.version;
+
+    // Fetch latest release version from GitHub
+    fetch('https://api.github.com/repos/coco-xyz/clawmark/releases/latest')
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+            const el = document.getElementById('about-latest-version');
+            if (data && data.tag_name) {
+                const latest = data.tag_name.replace(/^v/, '');
+                el.textContent = latest;
+                if (latest !== manifest.version) {
+                    el.style.color = '#f59e0b';
+                    el.textContent = `${latest} (update available)`;
+                }
+            } else {
+                el.textContent = '—';
+            }
+        })
+        .catch(() => {
+            document.getElementById('about-latest-version').textContent = '—';
+        });
 }
 
 // ------------------------------------------------------------------ Init


### PR DESCRIPTION
## Summary
- Add "Project" card with Official Website, GitHub Repository, and Releases links
- Add "Latest Release" check via GitHub API (fetches latest tag, shows update notification in amber if newer version available)
- Reorganize About tab: split into Project links + Help links

Closes #165

## Test plan
- [ ] Open About tab — verify current version shows
- [ ] Verify "Latest Release" fetches from GitHub API
- [ ] Verify Official Website links to labs.coco.xyz/clawmark/
- [ ] Verify GitHub / Releases / Issues / Privacy / Changelog links work

Generated with [Claude Code](https://claude.com/claude-code)