### PR TITLE
fix: add brand links to adapter footers (#171)

### DIFF
--- a/server/adapters/email.js
+++ b/server/adapters/email.js
@@ -155,7 +155,7 @@ class EmailAdapter {
         lines.push('</div>');
 
         // Footer
-        lines.push('<p style="font-size:11px;color:#9ca3af;margin:12px 0 0;text-align:center;">Sent by ClawMark</p>');
+        lines.push('<p style="font-size:11px;color:#9ca3af;margin:12px 0 0;text-align:center;">Sent by <a href="https://github.com/coco-xyz/clawmark" style="color:#9ca3af;">ClawMark</a> — Annotate any web page · <a href="https://labs.coco.xyz/clawmark/" style="color:#9ca3af;">Website</a></p>');
         lines.push('</body></html>');
 
         return lines.join('\n');

--- a/server/adapters/github-issue.js
+++ b/server/adapters/github-issue.js
@@ -228,7 +228,7 @@ class GitHubIssueAdapter {
         }
 
         lines.push('---');
-        lines.push('*Created by ClawMark*');
+        lines.push('*Created by [ClawMark](https://github.com/coco-xyz/clawmark) — Annotate any web page · [Website](https://labs.coco.xyz/clawmark/)*');
 
         return lines.join('\n');
     }

--- a/server/adapters/jira.js
+++ b/server/adapters/jira.js
@@ -246,7 +246,26 @@ class JiraAdapter {
         });
         nodes.push({
             type: 'paragraph',
-            content: [{ type: 'text', text: 'Created by ClawMark', marks: [{ type: 'em' }] }],
+            content: [
+                { type: 'text', text: 'Created by ', marks: [{ type: 'em' }] },
+                {
+                    type: 'text',
+                    text: 'ClawMark',
+                    marks: [
+                        { type: 'em' },
+                        { type: 'link', attrs: { href: 'https://github.com/coco-xyz/clawmark' } },
+                    ],
+                },
+                { type: 'text', text: ' — Annotate any web page · ', marks: [{ type: 'em' }] },
+                {
+                    type: 'text',
+                    text: 'Website',
+                    marks: [
+                        { type: 'em' },
+                        { type: 'link', attrs: { href: 'https://labs.coco.xyz/clawmark/' } },
+                    ],
+                },
+            ],
         });
 
         return {

--- a/server/adapters/linear.js
+++ b/server/adapters/linear.js
@@ -205,7 +205,7 @@ class LinearAdapter {
             lines.push('', `**Tags:** ${tags.join(', ')}`);
         }
 
-        lines.push('', '---', '*Created by ClawMark*');
+        lines.push('', '---', '*Created by [ClawMark](https://github.com/coco-xyz/clawmark) — Annotate any web page · [Website](https://labs.coco.xyz/clawmark/)*');
         return lines.join('\n');
     }
 

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -1230,7 +1230,7 @@ describe('LinearAdapter — description building', () => {
         assert.ok(desc.includes('ui'));
         assert.ok(desc.includes('regression'));
         assert.ok(desc.includes('Please fix ASAP'));
-        assert.ok(desc.includes('Created by ClawMark'));
+        assert.ok(desc.includes('ClawMark'));
     });
 
     it('handles missing optional fields', () => {
@@ -1241,7 +1241,7 @@ describe('LinearAdapter — description building', () => {
 
         const desc = adapter._buildDescription({}, {});
         assert.ok(desc.includes('normal'));
-        assert.ok(desc.includes('Created by ClawMark'));
+        assert.ok(desc.includes('ClawMark'));
     });
 
     it('handles string tags', () => {


### PR DESCRIPTION
## Summary
- GitHub Issue / Linear / Jira / Email adapters now include ClawMark website and GitHub repo links in footers
- Previously: just `Created by ClawMark` (plain text, no links)
- Now: `Created by ClawMark — Annotate any web page · Website` with hyperlinks to GitHub repo and labs.coco.xyz

Closes #171

## Adapters updated
- `github-issue.js` — Markdown links in issue body footer
- `linear.js` — Markdown links in issue description footer
- `jira.js` — ADF links in issue description footer
- `email.js` — HTML links in email footer

## Test plan
- [x] 513 tests pass
- [ ] Create a test annotation → verify GitHub issue footer has clickable links