### PR TITLE
fix: delivery hint on fallback + manage links to correct tab (#173, #174)

### DIFF
--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -459,6 +459,12 @@ async function handleMessage(message, sender) {
             }
         }
 
+        case 'OPEN_OPTIONS_TAB': {
+            const url = chrome.runtime.getURL(`options/options.html#${message.tab || 'overview'}`);
+            chrome.tabs.create({ url });
+            return { success: true };
+        }
+
         default:
             return { error: `Unknown message type: ${message.type}` };
     }

--- a/extension/content/inject.js
+++ b/extension/content/inject.js
@@ -717,8 +717,24 @@
                 <span class="cm-target-method">saved</span>
             </label>`;
 
+            // If no delivery rules matched, prompt user to add one
+            if (resolvedTargets.length === 0) {
+                html += `<div class="cm-dispatch-hint" style="margin-top:6px;font-size:11px;color:#888;cursor:pointer;"
+                    title="Open delivery rules settings">
+                    \u2795 Add a delivery rule to send annotations to GitHub, Jira, Email, etc.
+                </div>`;
+            }
+
             targetsEl.innerHTML = html;
             previewEl.style.display = 'block';
+
+            // Attach click handler for the "add delivery" hint
+            const hint = targetsEl.querySelector('.cm-dispatch-hint');
+            if (hint) {
+                hint.addEventListener('click', () => {
+                    chrome.runtime.sendMessage({ type: 'OPEN_OPTIONS_TAB', tab: 'delivery' });
+                });
+            }
         } catch {
             // Even on error, show the fallback
             targetsEl.innerHTML = `<label class="cm-dispatch-target cm-dispatch-fallback">

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -11,15 +11,26 @@
 const navItems = document.querySelectorAll('.nav-item');
 const tabPanels = document.querySelectorAll('.tab-panel');
 
+function switchTab(tab) {
+    navItems.forEach(n => n.classList.remove('active'));
+    tabPanels.forEach(p => p.classList.remove('active'));
+    const navItem = document.querySelector(`.nav-item[data-tab="${tab}"]`);
+    const panel = document.getElementById(`tab-${tab}`);
+    if (navItem && panel) {
+        navItem.classList.add('active');
+        panel.classList.add('active');
+    }
+}
+
 navItems.forEach(item => {
-    item.addEventListener('click', () => {
-        const tab = item.dataset.tab;
-        navItems.forEach(n => n.classList.remove('active'));
-        tabPanels.forEach(p => p.classList.remove('active'));
-        item.classList.add('active');
-        document.getElementById(`tab-${tab}`).classList.add('active');
-    });
+    item.addEventListener('click', () => switchTab(item.dataset.tab));
 });
+
+// Support deep-linking via URL hash (e.g. options.html#delivery)
+if (window.location.hash) {
+    const tab = window.location.hash.slice(1);
+    if (document.getElementById(`tab-${tab}`)) switchTab(tab);
+}
 
 // ------------------------------------------------------------------ toast
 

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -190,7 +190,7 @@ function formatTargetName(type, config) {
 }
 
 document.getElementById('btn-more-targets').addEventListener('click', () => {
-    chrome.runtime.openOptionsPage();
+    chrome.tabs.create({ url: chrome.runtime.getURL('options/options.html#delivery') });
     window.close();
 });
 


### PR DESCRIPTION
## Summary
- **#173**: When no delivery rules match (only ClawMark fallback shown), display a hint: "Add a delivery rule to send annotations to GitHub, Jira, Email, etc." Clicking it opens the Delivery Rules settings tab.
- **#174**: "Manage rules" button in popup now opens the Delivery tab directly (via `options.html#delivery`) instead of the default Overview tab. Options page now supports deep-linking via URL hash.

## Changes
- `extension/content/inject.js` — Add delivery hint UI when `resolvedTargets` is empty + click handler
- `extension/background/service-worker.js` — Handle `OPEN_OPTIONS_TAB` message to open options with hash
- `extension/options/options.js` — Extract `switchTab()` function, support `window.location.hash` on load
- `extension/popup/popup.js` — Change "Manage rules" to open `options.html#delivery`

## Test plan
- [x] 513 tests pass
- [ ] Verify fallback hint appears when no delivery rules configured
- [ ] Verify clicking hint opens Delivery tab in options
- [ ] Verify "Manage rules" button in popup opens Delivery tab

Closes #173, closes #174