### PR TITLE
docs: update CHANGELOG with v0.3.5 through v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 本项目遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 格式，版本号采用 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [0.6.2] — 2026-03-04
+
+### 新增
+
+- About 面板 — 项目卡片 + GitHub API 拉取最新版本 + 橙色徽章（#165, #166）
+- 配置面板重组 + 全局统计数据展示（#167, #170, #177）
+
+### 修复
+
+- 阻止 Google OAuth 在页面刷新时重复触发
+- Adapter 页脚添加品牌链接（#171, #172）
+- Fallback 投递提示 + 管理链接跳转到正确标签页（#173, #174, #175）
+
+### 文档
+
+- 重构 README — 介绍、托管 vs 自部署、链接更新（#168, #169）
+
+## [0.6.1] — 2026-03-04
+
+### 新增
+
+- Phase 1 — Dashboard + Popup 全新设计（#150, #158）
+- Phase 1.5 — 标注窗口覆盖层优化（#150）
+- Phase 2 — 欢迎页 + 徽章计数
+- Phase 3 打磨 — 错误 UX、加载进度条、快捷键提示、站点模式切换
+- 投递地址 fallback + 可见分发目标（#147）
+
+### 修复
+
+- 事件监听器清理 + 自定义标签双重提交 + 尺寸上限
+- 工具栏定位及文字标注输入问题（#143, #144）
+- 解决 review 反馈 — P1/P2/P3 问题修复
+
+### 文档
+
+- ClawMark UX 大改版 PRD（#150）+ 多次更新
+
+## [0.6.0] — 2026-03-02
+
+### 新增
+
+- 多目标分发框架（#93, #108）
+- Slack 和 Email adapters（#94, #107）
+- Linear、Jira、HxA Connect adapters（#95, #110）
+- 智能分发预览 + 状态展示（#115, #129）
+- 截图模式可拖拽标注层模型（#111, #131）
+- 截图 AI 视觉分析（#117, #137）
+- 扩展 popup 投递设置面板
+
+### 修复
+
+- 转义分发目标标签中的 HTML 以防止 XSS（#115, #130）
+- 优先使用认证身份而非 body userName，修复规则可见性 bug（#116, #128）
+- 默认服务器 URL 设为 api.coco.xyz/clawmark
+
+## [0.3.5] — 2026-03-01
+
+### 新增
+
+- Google OAuth 登录 + JWT 认证（#64）
+- 扩展添加 Google OAuth 登录（#67）
+- 应用管理 — 自助 App + AppKey 创建（#65）
+- 端点管理 UI 和 API（#66）
+- 组织/团队管理 + RBAC 权限体系（#68）
+- 截图标注 + 图片粘贴（#69, #70）
+
+### 修复
+
+- Google OAuth 安全加固 + /auth/google 测试
+- 路由规则 PUT 响应中 target_config 解析修复
+- 修复 v0.3.0 路由及认证关键 bug
+- org_id 索引创建顺序修正
+
+### 其他
+
+- 设置 Google OAuth Client ID
+- 产品路线图文档
+
 ## [0.5.0] — 2026-03-01
 
 ### 新增
@@ -120,8 +198,12 @@
 - JSON body 大小限制（512KB）
 - 不存在 item 的状态操作返回 404
 
+[0.6.2]: https://github.com/coco-xyz/clawmark/releases/tag/v0.6.2
+[0.6.1]: https://github.com/coco-xyz/clawmark/releases/tag/v0.6.1
+[0.6.0]: https://github.com/coco-xyz/clawmark/releases/tag/v0.6.0
 [0.5.0]: https://github.com/coco-xyz/clawmark/releases/tag/v0.5.0
 [0.4.0]: https://github.com/coco-xyz/clawmark/releases/tag/v0.4.0
+[0.3.5]: https://github.com/coco-xyz/clawmark/releases/tag/v0.3.5
 [0.3.0]: https://github.com/coco-xyz/clawmark/releases/tag/v0.3.0
 [0.2.0]: https://github.com/coco-xyz/clawmark/releases/tag/v0.2.0
 [0.1.0]: https://github.com/coco-xyz/clawmark/commits/0c02d6b


### PR DESCRIPTION
## Summary

- 补全 CHANGELOG.md 中缺失的版本记录：v0.3.5、v0.6.0、v0.6.1、v0.6.2
- 新增版本链接到 links 区域
- 沿用项目既有的中文 Keep a Changelog 格式

Refs #176

## Changes

| 版本 | 日期 | 主要内容 |
|------|------|----------|
| v0.3.5 | 2026-03-01 | Google OAuth + JWT 认证、应用管理、组织/团队 RBAC、截图标注 |
| v0.6.0 | 2026-03-02 | 多目标分发框架、Slack/Email/Linear/Jira/HxA adapters、AI 视觉分析 |
| v0.6.1 | 2026-03-04 | Dashboard+Popup 全新设计、欢迎页、标注覆盖层优化 |
| v0.6.2 | 2026-03-04 | About 面板、配置面板重组、OAuth 修复、README 重构 |

## Test plan

- [ ] 验证 Markdown 渲染正确（版本号链接、issue 引用）
- [ ] 确认版本顺序从新到旧排列
- [ ] 确认 links 区域包含所有版本

🤖 Generated with [Claude Code](https://claude.com/claude-code)