### PR TITLE
chore: bump version to v0.6.3

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "ClawMark",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "Annotate, comment, and track issues on any webpage — your feedback collection tool",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApkQ68vPnMba+IXLSgvs/91voPszurmDMdFQx6pEqi8bcSsGZr05NJ1VvFpVMu3X/lml6ZBLPfxdeJef803Hw3LH1g50FsvRS7OyooYkyzU7W3BXd4yBsaUUG7jdk4eVnaxTtINVXL0Z6YHAlA2YAV/e3tW7lY1MDYT+Fhpw2V4pOM5wNPD8NxPzSQxKiCZBN75aTHaHHz0LvXegSit3v8MXnmcWlBQNbCaK2aOAJbyVTv2jn+NR4VXKXNvK1cgLHJmGuXtdojBZwclyLSJ4jdDtM5uKQg509o8qljcrAGNU6fuO5ryLqS0EB3s/uN600LfuFqWGVJF1Wv/FpTgAyQwIDAQAB",
     "permissions": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawmark",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AI-native feedback & collaboration widget — annotate, comment, and track issues on any web page",
   "main": "server/index.js",
   "scripts": {


### PR DESCRIPTION
Version bump for v0.6.3 release.

- package.json: 0.6.2 → 0.6.3
- manifest.json: 0.6.2 → 0.6.3

Already merged on GitLab (MR !5).