### PR TITLE
fix: add CORS support for cross-origin Dashboard access

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -136,6 +136,23 @@ if (WEBHOOK.url && !config.distribution) {
 // ---------------------------------------------------------------------- express
 
 const app = express();
+
+// ---------------------------------------------------------------------- CORS
+const ALLOWED_ORIGINS = config.allowedOrigins || [];
+if (ALLOWED_ORIGINS.length) {
+    app.use((req, res, next) => {
+        const origin = req.headers.origin;
+        if (origin && ALLOWED_ORIGINS.includes(origin)) {
+            res.setHeader('Access-Control-Allow-Origin', origin);
+            res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
+            res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+            res.setHeader('Access-Control-Allow-Credentials', 'true');
+            if (req.method === 'OPTIONS') return res.sendStatus(204);
+        }
+        next();
+    });
+}
+
 app.use(express.json({ limit: '512kb' }));
 
 // Trust first proxy (for correct IP logging behind nginx/caddy)


### PR DESCRIPTION
## Summary

Dashboard on `labs.coco.xyz` calls API on `api.coco.xyz` — cross-origin request, browser blocks without CORS headers → "Login failed: Failed to fetch".

Adds configurable CORS middleware via `config.allowedOrigins` array. Only 1 file changed (server/index.js, +17 lines).

## Deploy

Production config.json add:
```json
"allowedOrigins": ["https://labs.coco.xyz"]
```

## Related
- GitLab MR !38

🤖 Generated with [Claude Code](https://claude.com/claude-code)