### PR TITLE
sync: v0.7.0 — dashboard URL fix, CORS, signout style

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -103,7 +103,7 @@
                         <div class="sidebar-account-email" id="sidebar-account-email"></div>
                     </div>
                 </div>
-                <button class="btn btn-danger btn-small" id="btn-sign-out">Sign Out</button>
+                <button class="btn btn-ghost btn-small" id="btn-sign-out">Sign Out</button>
             </div>
         </nav>
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,3 +1,43 @@
+# Deployment Guide
+
+## COCO Environments
+
+ClawMark has two official environments. Extension builds are configured via `scripts/build.sh`.
+
+### Production
+
+| Component | URL |
+|-----------|-----|
+| API Server | `https://api.coco.xyz/clawmark` |
+| Dashboard | `https://labs.coco.xyz/clawmark/dashboard` |
+| Google OAuth Client ID | `530440081185-32t15m4gqndq7qab6g57a25i6gfc1gmn.apps.googleusercontent.com` |
+
+```bash
+./scripts/build.sh production
+```
+
+### Test
+
+| Component | URL |
+|-----------|-----|
+| API Server | `https://jessie.coco.site/clawmark` |
+| Dashboard | `https://jessie.coco.site/clawmark-dashboard/` |
+| Google OAuth Client ID | Same as production |
+
+```bash
+./scripts/build.sh test
+```
+
+### Build Output
+
+Each build generates `extension/config.js` (gitignored) and a zip file:
+- `clawmark-v{VERSION}-test.zip`
+- `clawmark-v{VERSION}-production.zip`
+
+Both zips are uploaded to GitHub Releases and hosted at `jessie.coco.site/`.
+
+---
+
 # Self-Hosted Deployment Guide
 
 ## Quick Start
@@ -126,6 +166,18 @@ data/
 curl http://localhost:3458/health
 # Returns: {"status":"ok","version":"2.0.0"}
 ```
+
+## CORS (Cross-Origin Dashboard)
+
+If the Dashboard is hosted on a different domain than the API (e.g., Dashboard on `labs.coco.xyz`, API on `api.coco.xyz`), add the Dashboard origin to `config.json`:
+
+```json
+{
+  "allowedOrigins": ["https://labs.coco.xyz"]
+}
+```
+
+Without this, the browser will block Dashboard → API requests with a CORS error ("Failed to fetch").
 
 ## Authentication
 

--- a/extension/background/service-worker.js
+++ b/extension/background/service-worker.js
@@ -290,7 +290,7 @@ async function uploadImage(dataUrl) {
 
 chrome.runtime.onInstalled.addListener((details) => {
     if (details.reason === 'install') {
-        const dashUrl = ClawMarkConfig.DASHBOARD_URL || 'https://labs.coco.xyz/clawmark/dash/';
+        const dashUrl = ClawMarkConfig.DASHBOARD_URL || 'https://labs.coco.xyz/clawmark/dashboard';
         chrome.tabs.create({ url: dashUrl + '#welcome' });
     }
 
@@ -538,12 +538,9 @@ async function handleMessage(message, sender) {
             return checkForUpdate();
 
         case 'OPEN_OPTIONS_PAGE': {
-            (async () => {
-                const cfg = await getConfig();
-                const base = cfg.serverUrl.replace(/\/+$/, '').replace(/\/api\/.*$/, '').replace(/\/clawmark\/?$/, '');
-                const hash = message.hash ? `#${message.hash}` : '';
-                chrome.tabs.create({ url: base + '/clawmark-dashboard/' + hash });
-            })();
+            const dashUrl = ClawMarkConfig.DASHBOARD_URL || 'https://labs.coco.xyz/clawmark/dashboard';
+            const hash = message.hash ? '#' + message.hash : '';
+            chrome.tabs.create({ url: dashUrl + hash });
             return { success: true };
         }
 

--- a/extension/config.example.js
+++ b/extension/config.example.js
@@ -11,7 +11,7 @@
 
 const ClawMarkConfig = {
     DEFAULT_SERVER: 'https://api.coco.xyz/clawmark',
-    DASHBOARD_URL: 'https://labs.coco.xyz/clawmark/dash/',
+    DASHBOARD_URL: 'https://labs.coco.xyz/clawmark/dashboard',
     GOOGLE_CLIENT_ID: 'YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com',
     EXTENSION_ID: '',
     ENV: 'production',

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "ClawMark",
-    "version": "0.6.9",
+    "version": "0.7.0",
     "description": "Annotate, comment, and track issues on any webpage — your feedback collection tool",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApkQ68vPnMba+IXLSgvs/91voPszurmDMdFQx6pEqi8bcSsGZr05NJ1VvFpVMu3X/lml6ZBLPfxdeJef803Hw3LH1g50FsvRS7OyooYkyzU7W3BXd4yBsaUUG7jdk4eVnaxTtINVXL0Z6YHAlA2YAV/e3tW7lY1MDYT+Fhpw2V4pOM5wNPD8NxPzSQxKiCZBN75aTHaHHz0LvXegSit3v8MXnmcWlBQNbCaK2aOAJbyVTv2jn+NR4VXKXNvK1cgLHJmGuXtdojBZwclyLSJ4jdDtM5uKQg509o8qljcrAGNU6fuO5ryLqS0EB3s/uN600LfuFqWGVJF1Wv/FpTgAyQwIDAQAB",
     "permissions": [

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -58,7 +58,7 @@
     <script>
         'use strict';
         const dashUrl = (typeof ClawMarkConfig !== 'undefined' && ClawMarkConfig.DASHBOARD_URL)
-            || 'https://labs.coco.xyz/clawmark/dash/';
+            || 'https://labs.coco.xyz/clawmark/dashboard';
 
         // Transfer hash from extension URL to dashboard URL
         const hash = location.hash.slice(1);

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -69,7 +69,7 @@ masterToggle.addEventListener('change', async () => {
 
 function openDashboard(hash) {
     const base = (typeof ClawMarkConfig !== 'undefined' && ClawMarkConfig.DASHBOARD_URL)
-        || 'https://labs.coco.xyz/clawmark/dash/';
+        || 'https://labs.coco.xyz/clawmark/dashboard';
     const url = hash ? base + '#' + hash : base;
     chrome.tabs.create({ url });
     window.close();

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -39,7 +39,7 @@ case "$ENV" in
     ;;
   production)
     SERVER_URL="https://api.coco.xyz/clawmark"
-    DASHBOARD_URL="https://labs.coco.xyz/clawmark/dash/"
+    DASHBOARD_URL="https://labs.coco.xyz/clawmark/dashboard"
     ;;
   *)
     err "Unknown environment: $ENV (use 'test' or 'production')"


### PR DESCRIPTION
## Summary
Sync from GitLab `main` after v0.7.0 release.

- fix: correct dashboard URLs in OPEN_OPTIONS_PAGE handler + align fallbacks (#29)
- fix: soften signout button style (#31)
- fix: CORS support for cross-origin Dashboard access
- docs: deployment guide (CORS, COCO env config)
- chore: bump to v0.7.0

GitLab Release: https://git.coco.xyz/hxanet/clawmark/-/releases/v0.7.0